### PR TITLE
Ajuste nas validações de altura e largura

### DIFF
--- a/src/tests/Calculator.test.jsx
+++ b/src/tests/Calculator.test.jsx
@@ -6,7 +6,7 @@ import renderTest from './renderWithRouter';
 import Calculator from '../views/Calculator';
 
 const formParameters = [
-  12, 5, 2, 2, 15, 1, 1, 0, 5, 15, 0, 2, 14, 3, 0, 0,
+  12, 5, 2, 2, 10, 1.5, 1, 0, 5, 15, 0, 2, 14, 3, 0, 0,
 ];
 
 describe('1 - Testa se a aplicação retornar os valores esperados', () => {
@@ -28,38 +28,38 @@ describe('1 - Testa se a aplicação retornar os valores esperados', () => {
     expect(paintCanGallons).toBeInTheDocument();
   });
 
-  it('Deve retornar 11.48 de área a ser pintada e sugerir 1 lata de 2.5L', () => {
-    const { getAllByRole, getByRole, getByText } = renderTest(<Calculator />);
-
-    const inputs = getAllByRole('textbox');
-    const submitButton = getByRole('button', { name: /calcular/i });
-
-    fireEvent.change(inputs[0], { target: { value: 5 } });
-    fireEvent.change(inputs[1], { target: { value: 2 } });
-    fireEvent.change(inputs[3], { target: { value: 1 } });
-
-    fireEvent.click(submitButton);
-
-    const correctResult = getByText(/11.48 metros/i);
-    const paintCanLarge = getByText(/1 lata de 2.5l/i);
-
-    expect(correctResult).toBeInTheDocument();
-    expect(paintCanLarge).toBeInTheDocument();
-  });
-
-  it('Deve retornar 9.48 de área a ser pintada e sugerir 4 latas de 0.5L', () => {
+  it('Deve retornar 10.28 de área a ser pintada e sugerir 1 lata de 2.5L', () => {
     const { getAllByRole, getByRole, getByText } = renderTest(<Calculator />);
 
     const inputs = getAllByRole('textbox');
     const submitButton = getByRole('button', { name: /calcular/i });
 
     fireEvent.change(inputs[0], { target: { value: 4 } });
-    fireEvent.change(inputs[1], { target: { value: 2 } });
+    fireEvent.change(inputs[1], { target: { value: 2.2 } });
     fireEvent.change(inputs[3], { target: { value: 1 } });
 
     fireEvent.click(submitButton);
 
-    const correctResult = getByText(/9.48 metros/i);
+    const correctResult = getByText(/10.28 metros/i);
+    const paintCanLarge = getByText(/1 lata de 2.5l/i);
+
+    expect(correctResult).toBeInTheDocument();
+    expect(paintCanLarge).toBeInTheDocument();
+  });
+
+  it('Deve retornar 8.08 de área a ser pintada e sugerir 4 latas de 0.5L', () => {
+    const { getAllByRole, getByRole, getByText } = renderTest(<Calculator />);
+
+    const inputs = getAllByRole('textbox');
+    const submitButton = getByRole('button', { name: /calcular/i });
+
+    fireEvent.change(inputs[0], { target: { value: 3 } });
+    fireEvent.change(inputs[1], { target: { value: 2.2 } });
+    fireEvent.change(inputs[3], { target: { value: 1 } });
+
+    fireEvent.click(submitButton);
+
+    const correctResult = getByText(/8.08 metros/i);
     const paintCanLarge = getByText(/4 latas de 0.5l/i);
 
     expect(correctResult).toBeInTheDocument();
@@ -98,7 +98,7 @@ describe('2 - Testa se a aplicação gera os erros corretamente', () => {
     const inputs = getAllByRole('textbox');
 
     fireEvent.change(inputs[8], { target: { value: 5 } });
-    fireEvent.change(inputs[9], { target: { value: 2 } });
+    fireEvent.change(inputs[9], { target: { value: 2.2 } });
     fireEvent.change(inputs[10], { target: { value: 2 } });
     fireEvent.change(inputs[11], { target: { value: 1 } });
 

--- a/src/tests/Calculator.test.jsx
+++ b/src/tests/Calculator.test.jsx
@@ -68,14 +68,29 @@ describe('1 - Testa se a aplicação retornar os valores esperados', () => {
 });
 
 describe('2 - Testa se a aplicação gera os erros corretamente', () => {
-  it('Deve informar altura inválida quando houver porta em parede com menos de 1.1 metros', () => {
+  it('Deve informar altura inválida quando houver porta em parede com menos de 2.2 metros', () => {
     const { getAllByRole, getByText } = renderTest(<Calculator />);
 
     const inputs = getAllByRole('textbox');
 
+    fireEvent.change(inputs[1], { target: { value: 2.1 } });
     fireEvent.change(inputs[3], { target: { value: 1 } });
 
     const errorMessage = getByText(/\*a parede deve ser no mínimo 30 centímetros mais alta que a porta/i);
+
+    expect(errorMessage).toBeInTheDocument();
+  });
+
+  it('Deve informar altura inválida quando houver janela em parede com menos de 1.5 metros', () => {
+    const { getAllByRole, getByText } = renderTest(<Calculator />);
+
+    const inputs = getAllByRole('textbox');
+
+    fireEvent.change(inputs[0], { target: { value: 2.3 } });
+    fireEvent.change(inputs[1], { target: { value: 1.4 } });
+    fireEvent.change(inputs[2], { target: { value: 1 } });
+
+    const errorMessage = getByText(/\*a parede deve ser no mínimo 30 centímetros mais alta que a janela/i);
 
     expect(errorMessage).toBeInTheDocument();
   });

--- a/src/utils/validateWallParameters.js
+++ b/src/utils/validateWallParameters.js
@@ -4,6 +4,7 @@ const MIN_VALUE_ERROR = 'não pode ser inferior a 1 metro';
 const MAX_VALUE_ERROR = 'não pode ser superior a 15 metros';
 const MINIMUN_WALL_AREA_ERROR = 'Portas e janelas podem ocupar no máximo 50% da área da parede';
 const MINIMUN_HEIGHT_WITH_DOOR = 'A parede deve ser no mínimo 30 centímetros mais alta que a porta';
+const MINIMUN_HEIGHT_WITH_WINDOW = 'A parede deve ser no mínimo 30 centímetros mais alta que a janela';
 const MINIMUN_WIDTH_WITH_DOOR = 'A parede deve ser no mínimo 30 centímetros mais larga que a janela';
 
 const validateWidth = (width, windows) => {
@@ -13,10 +14,11 @@ const validateWidth = (width, windows) => {
   return null;
 };
 
-const validateHeight = (height, doors) => {
+const validateHeight = (height, doors, windows) => {
   if (height < 1) return `Altura ${MIN_VALUE_ERROR}`;
   if (height > 15) return `Altura ${MAX_VALUE_ERROR}`;
-  if (doors > 0 && height < 1.1) return MINIMUN_HEIGHT_WITH_DOOR;
+  if (doors > 0 && height < 2.2) return MINIMUN_HEIGHT_WITH_DOOR;
+  if (windows > 0 && height < 1.5) return MINIMUN_HEIGHT_WITH_WINDOW;
   return null;
 };
 
@@ -33,6 +35,6 @@ export default ({
   width, height, doors, windows,
 }) => (
   validateWidth(width, windows)
-  || validateHeight(height, doors)
+  || validateHeight(height, doors, windows)
   || validateTotalArea(width, height, doors, windows)
 );


### PR DESCRIPTION
Corrigido valores mínimos para janelas e portas:
- Portas: altura mínima: 2.2 metros
- Janelas: altura mínima 1.5 metros
- Incluído testes